### PR TITLE
koch: reduce line length on every iteration

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -19,7 +19,7 @@
 <div id="top"><div class="inner"><h1>papert&#8213;logo in your browser</h1>
 <h2>
 examples:
-<a href="/_REo_2F2">koch snowflake</a>,
+<a href="/hcamjazq">koch snowflake</a>,
 <a href="/dZ1f62XY">hilbert curve</a>, 
 <a href="/8kpcBaQu">spiral</a>
 </h2>

--- a/koch.txt
+++ b/koch.txt
@@ -1,18 +1,21 @@
 to line :count :length
-ifelse :count = 1 [fw :length] [
-make "count :count -1 
-line :count :length
-lt 60 line :count :length
-rt 120 line :count :length
-lt 60 line :count :length]
+ ifelse :count = 1 [fw :length] 
+ [
+   make "count :count -1 
+   make "length :length /3
+   line :count :length
+   lt 60 line :count :length
+   rt 120 line :count :length
+   lt 60 line :count :length
+  ]
 end
 
 to koch :count :length
-rt 30 line :count :length
-rt 120 line :count :length
-rt 120 line :count :length
+  rt 30 line :count :length
+  rt 120 line :count :length
+  rt 120 line :count :length
 end
 
 reset
-setxy  10 400
-koch 5 4
+setxy  45 370
+koch 5 405


### PR DESCRIPTION
Change koch's :length argument is now the length of the base triangle. This simplifies experimenting with changing the number of recursion levels.

Koch.txt had a slightly different formatting than the version linked from index.html.tmpl, so I am importing the version that is included in the public instance and patching that one.